### PR TITLE
Add GitHub Action to auto-merge release PRs

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,39 @@
+name: Auto-merge Release PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login == 'scala-steward-wvlet[bot]' &&
+      startsWith(github.event.pull_request.title, 'Release wvlet')
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Enable auto-merge
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --auto \
+            --merge \
+            --subject "Auto-merge: ${{ github.event.pull_request.title }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Auto-approve PR
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --approve \
+            --body "Auto-approved release PR from scala-steward-wvlet bot"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Action workflow that automatically merges PRs from the scala-steward-wvlet bot
- Targets PRs with titles starting with "Release wvlet" (e.g., "Release wvlet 2025.1.12")
- Automatically approves and enables auto-merge for these PRs

## How it works
1. The workflow triggers on PR open/synchronize events
2. Checks if the PR is from `scala-steward-wvlet[bot]` and has a release title
3. Auto-approves the PR
4. Enables auto-merge to merge when all checks pass

## Test plan
- [ ] Workflow syntax is valid
- [ ] Next release PR from scala-steward-wvlet bot should be auto-merged
- [ ] Non-release PRs should not be affected

🤖 Generated with Claude Code
https://claude.ai/code