### PR TITLE
Fix auto-merge workflow: approve PR before enabling auto-merge

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -48,19 +48,19 @@ jobs:
             echo "No changes to commit"
           fi
       
+      - name: Auto-approve PR
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --approve \
+            --body "Auto-approved release PR from scala-steward-wvlet bot"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Enable auto-merge
         run: |
           gh pr merge ${{ github.event.pull_request.number }} \
             --auto \
             --squash \
             --subject "Auto-merge: ${{ github.event.pull_request.title }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Auto-approve PR
-        run: |
-          gh pr review ${{ github.event.pull_request.number }} \
-            --approve \
-            --body "Auto-approved release PR from scala-steward-wvlet bot"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Reorder workflow steps to approve PR before enabling auto-merge
- This resolves the 'Pull request is in clean status' GraphQL error
- Auto-merge requires approval or branch protection rules to be effective

## Problem
The auto-merge workflow was failing with the error: "Pull request Pull request is in clean status (enablePullRequestAutoMerge)"

## Root Cause
GitHub's auto-merge can only be enabled when:
1. There are pending status checks, OR
2. The PR has been approved, OR  
3. Branch protection rules are configured

The workflow was trying to enable auto-merge before approving the PR, causing the "clean status" error.

## Solution
Reordered the workflow steps to:
1. First approve the PR
2. Then enable auto-merge

This ensures auto-merge has the necessary conditions to be enabled successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)