### PR TITLE
Upgrade OpenJDK from 21 to 25

### DIFF
--- a/wvlet.rb
+++ b/wvlet.rb
@@ -6,12 +6,12 @@ class Wvlet < Formula
   sha256 "9f3da8865296284207f55e447eb142dbec89d6aa0721985c53553e58ea27badf"
   license "Apache-2.0"
 
-  depends_on "openjdk@21"
-  
+  depends_on "openjdk@25"
+
   def install
     libexec.install Dir["*"]
     bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Language::Java.overridable_java_home_env("21")[:JAVA_HOME])
+    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Language::Java.overridable_java_home_env("25")[:JAVA_HOME])
   end
 
   test do

--- a/wvlet.rb.template
+++ b/wvlet.rb.template
@@ -6,12 +6,12 @@ class Wvlet < Formula
   sha256 "${SHA256}"
   license "Apache-2.0"
 
-  depends_on "openjdk@21"
-  
+  depends_on "openjdk@25"
+
   def install
     libexec.install Dir["*"]
     bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Language::Java.overridable_java_home_env("21")[:JAVA_HOME])
+    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Language::Java.overridable_java_home_env("25")[:JAVA_HOME])
   end
 
   test do


### PR DESCRIPTION
## Summary
This PR upgrades the OpenJDK dependency from version 21 to version 25, updating both the main formula and template files.

## Changes
- Updated `openjdk@21` to `openjdk@25` in dependency declaration
- Updated Java version references from `21` to `25` in the install method
- Applied changes to both `wvlet.rb` and `wvlet.rb.template`

## Test plan
- [ ] Verify the formula builds successfully with OpenJDK 25
- [ ] Confirm the wvlet CLI tool runs correctly with the new JDK version
- [ ] Test on macOS to ensure compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)